### PR TITLE
fix offsets in cuda kernel for correlatin map

### DIFF
--- a/networks/correlation_package/src/correlation_cuda_kernel.cu
+++ b/networks/correlation_package/src/correlation_cuda_kernel.cu
@@ -50,8 +50,8 @@ __global__ void Correlation_forward( float *output, int nOutputChannels, int out
     int displacement_size = 2 * displacement_rad + 1;
 
     int n  = blockIdx.x;
-    int y1 = blockIdx.y * stride1 + max_displacement;
-    int x1 = blockIdx.z * stride1 + max_displacement;
+    int y1 = blockIdx.y * stride1 + max_displacement + kernel_rad;
+    int x1 = blockIdx.z * stride1 + max_displacement + kernel_rad;
     int c = threadIdx.x;
 
     int pdimyxc = pInputHeight * pInputWidth * nInputChannels;


### PR DESCRIPTION
After carefully reading I'm confused that `x1` and `y1` are only added by `max_displacement`. Rather I think they should be added by `max_displacement + kernel_rad`. Not sure whether I'm right.