### PR TITLE
add saving flow visualization image switch when saving flow

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,6 +45,8 @@ if __name__ == '__main__':
     parser.add_argument('--render_validation', action='store_true', help='run inference (save flows to file) and every validation_frequency epoch')
 
     parser.add_argument('--inference', action='store_true')
+    parser.add_argument('--inference_visualize', action='store_true',
+                        help="visualize the optical flow during inference")
     parser.add_argument('--inference_size', type=int, nargs='+', default = [-1,-1], help='spatial size divisible by 64. default (-1,-1) - largest possible valid size would be used')
     parser.add_argument('--inference_batch_size', type=int, default=1)
     parser.add_argument('--inference_n_batches', type=int, default=-1)
@@ -346,7 +348,12 @@ if __name__ == '__main__':
             flow_folder = "{}/inference/{}.epoch-{}-flow-field".format(args.save,args.name.replace('/', '.'),epoch)
             if not os.path.exists(flow_folder):
                 os.makedirs(flow_folder)
-
+        
+        # visualization folder
+        if args.inference_visualize:
+            flow_vis_folder = "{}/inference/{}.epoch-{}-flow-vis".format(args.save, args.name.replace('/', '.'), epoch)
+            if not os.path.exists(flow_vis_folder):
+                os.makedirs(flow_vis_folder)
         
         args.inference_n_batches = np.inf if args.inference_n_batches < 0 else args.inference_n_batches
 
@@ -380,7 +387,13 @@ if __name__ == '__main__':
                 for i in range(args.inference_batch_size):
                     _pflow = output[i].data.cpu().numpy().transpose(1, 2, 0)
                     flow_utils.writeFlow( join(flow_folder, '%06d.flo'%(batch_idx * args.inference_batch_size + i)),  _pflow)
-
+                    
+                    # You can comment out the plt block in visulize_flow_file() for real-time visualization
+                    if args.inference_visualize:
+                        flow_utils.visulize_flow_file(
+                            join(flow_folder, '%06d.flo' % (batch_idx * args.inference_batch_size + i)),flow_vis_folder)
+                   
+                            
             progress.set_description('Inference Averages for Epoch {}: '.format(epoch) + tools.format_dictionary_of_losses(loss_labels, np.array(statistics).mean(axis=0)))
             progress.update(1)
 

--- a/utils/flow_utils.py
+++ b/utils/flow_utils.py
@@ -1,4 +1,6 @@
 import numpy as np
+import matplotlib.pyplot as plt
+import os.path
 
 TAG_CHAR = np.array([202021.25], np.float32)
 
@@ -53,3 +55,150 @@ def writeFlow(filename,uv,v=None):
     tmp[:,np.arange(width)*2 + 1] = v
     tmp.astype(np.float32).tofile(f)
     f.close()
+
+
+# ref: https://github.com/sampepose/flownet2-tf/
+# blob/18f87081db44939414fc4a48834f9e0da3e69f4c/src/flowlib.py#L240
+def visulize_flow_file(flow_filename, save_dir=None):
+	flow_data = readFlow(flow_filename)
+	img = flow2img(flow_data)
+	# plt.imshow(img)
+	# plt.show()
+	if save_dir:
+		idx = flow_filename.rfind("/") + 1
+		plt.imsave(os.path.join(save_dir, "%s-vis.png" % flow_filename[idx:-4]), img)
+
+
+def flow2img(flow_data):
+	"""
+	convert optical flow into color image
+	:param flow_data:
+	:return: color image
+	"""
+	# print(flow_data.shape)
+	# print(type(flow_data))
+	u = flow_data[:, :, 0]
+	v = flow_data[:, :, 1]
+
+	UNKNOW_FLOW_THRESHOLD = 1e7
+	pr1 = abs(u) > UNKNOW_FLOW_THRESHOLD
+	pr2 = abs(v) > UNKNOW_FLOW_THRESHOLD
+	idx_unknown = (pr1 | pr2)
+	u[idx_unknown] = v[idx_unknown] = 0
+
+	# get max value in each direction
+	maxu = -999.
+	maxv = -999.
+	minu = 999.
+	minv = 999.
+	maxu = max(maxu, np.max(u))
+	maxv = max(maxv, np.max(v))
+	minu = min(minu, np.min(u))
+	minv = min(minv, np.min(v))
+
+	rad = np.sqrt(u ** 2 + v ** 2)
+	maxrad = max(-1, np.max(rad))
+	u = u / maxrad + np.finfo(float).eps
+	v = v / maxrad + np.finfo(float).eps
+
+	img = compute_color(u, v)
+
+	idx = np.repeat(idx_unknown[:, :, np.newaxis], 3, axis=2)
+	img[idx] = 0
+
+	return np.uint8(img)
+
+
+def compute_color(u, v):
+	"""
+	compute optical flow color map
+	:param u: horizontal optical flow
+	:param v: vertical optical flow
+	:return:
+	"""
+
+	height, width = u.shape
+	img = np.zeros((height, width, 3))
+
+	NAN_idx = np.isnan(u) | np.isnan(v)
+	u[NAN_idx] = v[NAN_idx] = 0
+
+	colorwheel = make_color_wheel()
+	ncols = np.size(colorwheel, 0)
+
+	rad = np.sqrt(u ** 2 + v ** 2)
+
+	a = np.arctan2(-v, -u) / np.pi
+
+	fk = (a + 1) / 2 * (ncols - 1) + 1
+
+	k0 = np.floor(fk).astype(int)
+
+	k1 = k0 + 1
+	k1[k1 == ncols + 1] = 1
+	f = fk - k0
+
+	for i in range(0, np.size(colorwheel, 1)):
+		tmp = colorwheel[:, i]
+		col0 = tmp[k0 - 1] / 255
+		col1 = tmp[k1 - 1] / 255
+		col = (1 - f) * col0 + f * col1
+
+		idx = rad <= 1
+		col[idx] = 1 - rad[idx] * (1 - col[idx])
+		notidx = np.logical_not(idx)
+
+		col[notidx] *= 0.75
+		img[:, :, i] = np.uint8(np.floor(255 * col * (1 - NAN_idx)))
+
+	return img
+
+
+def make_color_wheel():
+	"""
+	Generate color wheel according Middlebury color code
+	:return: Color wheel
+	"""
+	RY = 15
+	YG = 6
+	GC = 4
+	CB = 11
+	BM = 13
+	MR = 6
+
+	ncols = RY + YG + GC + CB + BM + MR
+
+	colorwheel = np.zeros([ncols, 3])
+
+	col = 0
+
+	# RY
+	colorwheel[0:RY, 0] = 255
+	colorwheel[0:RY, 1] = np.transpose(np.floor(255 * np.arange(0, RY) / RY))
+	col += RY
+
+	# YG
+	colorwheel[col:col + YG, 0] = 255 - np.transpose(np.floor(255 * np.arange(0, YG) / YG))
+	colorwheel[col:col + YG, 1] = 255
+	col += YG
+
+	# GC
+	colorwheel[col:col + GC, 1] = 255
+	colorwheel[col:col + GC, 2] = np.transpose(np.floor(255 * np.arange(0, GC) / GC))
+	col += GC
+
+	# CB
+	colorwheel[col:col + CB, 1] = 255 - np.transpose(np.floor(255 * np.arange(0, CB) / CB))
+	colorwheel[col:col + CB, 2] = 255
+	col += CB
+
+	# BM
+	colorwheel[col:col + BM, 2] = 255
+	colorwheel[col:col + BM, 0] = np.transpose(np.floor(255 * np.arange(0, BM) / BM))
+	col += + BM
+
+	# MR
+	colorwheel[col:col + MR, 2] = 255 - np.transpose(np.floor(255 * np.arange(0, MR) / MR))
+	colorwheel[col:col + MR, 0] = 255
+
+	return colorwheel


### PR DESCRIPTION
When saving optical flow output, I also wanna save the visualization images, which seems not provided right now. 

Based on the Yuliang-Zhang's recommendation in  [_issue#13_](https://github.com/NVIDIA/flownet2-pytorch/issues/13), I've added an arg option named `inference_visualize` and related code. When the switch is on, the visualization images will be saved at the same output folder you specified.

A sample inference executing command may  as follows:
`$ python main.py --inference --model FlowNet2SD --save_flow  --save output  --inference_visualize --inference_dataset ImagesFromFolder  --inference_dataset_root <path/to/your/dataset> --resume <path/to/ckpt file> `

**_Reference:_**
https://github.com/sampepose/flownet2-tf/blob/master/src/flowlib.py