### PR TITLE
use static forward and backward methods

### DIFF
--- a/networks/correlation_package/correlation.py
+++ b/networks/correlation_package/correlation.py
@@ -5,31 +5,30 @@ import correlation_cuda
 
 class CorrelationFunction(Function):
 
-    def __init__(self, pad_size=3, kernel_size=3, max_displacement=20, stride1=1, stride2=2, corr_multiply=1):
-        super(CorrelationFunction, self).__init__()
-        self.pad_size = pad_size
-        self.kernel_size = kernel_size
-        self.max_displacement = max_displacement
-        self.stride1 = stride1
-        self.stride2 = stride2
-        self.corr_multiply = corr_multiply
-        # self.out_channel = ((max_displacement/stride2)*2 + 1) * ((max_displacement/stride2)*2 + 1)
+    @staticmethod
+    def forward(ctx, input1, input2, pad_size=3, kernel_size=3, max_displacement=20, stride1=1, stride2=2, corr_multiply=1):
+        ctx.save_for_backward(input1, input2)
 
-    def forward(self, input1, input2):
-        self.save_for_backward(input1, input2)
+        ctx.pad_size = pad_size
+        ctx.kernel_size = kernel_size
+        ctx.max_displacement = max_displacement
+        ctx.stride1 = stride1
+        ctx.stride2 = stride2
+        ctx.corr_multiply = corr_multiply
 
         with torch.cuda.device_of(input1):
             rbot1 = input1.new()
             rbot2 = input2.new()
             output = input1.new()
 
-            correlation_cuda.forward(input1, input2, rbot1, rbot2, output, 
-                self.pad_size, self.kernel_size, self.max_displacement,self.stride1, self.stride2, self.corr_multiply)
+            correlation_cuda.forward(input1, input2, rbot1, rbot2, output,
+                ctx.pad_size, ctx.kernel_size, ctx.max_displacement, ctx.stride1, ctx.stride2, ctx.corr_multiply)
 
         return output
 
-    def backward(self, grad_output):
-        input1, input2 = self.saved_tensors
+    @staticmethod
+    def backward(ctx, grad_output):
+        input1, input2 = ctx.saved_tensors
 
         with torch.cuda.device_of(input1):
             rbot1 = input1.new()
@@ -39,9 +38,9 @@ class CorrelationFunction(Function):
             grad_input2 = input2.new()
 
             correlation_cuda.backward(input1, input2, rbot1, rbot2, grad_output, grad_input1, grad_input2,
-                self.pad_size, self.kernel_size, self.max_displacement,self.stride1, self.stride2, self.corr_multiply)
+                ctx.pad_size, ctx.kernel_size, ctx.max_displacement, ctx.stride1, ctx.stride2, ctx.corr_multiply)
 
-        return grad_input1, grad_input2
+        return grad_input1, grad_input2, None, None, None, None, None, None
 
 
 class Correlation(Module):
@@ -56,7 +55,7 @@ class Correlation(Module):
 
     def forward(self, input1, input2):
 
-        result = CorrelationFunction(self.pad_size, self.kernel_size, self.max_displacement,self.stride1, self.stride2, self.corr_multiply)(input1, input2)
+        result = CorrelationFunction.apply(input1, input2, self.pad_size, self.kernel_size, self.max_displacement, self.stride1, self.stride2, self.corr_multiply)
 
         return result
 


### PR DESCRIPTION
Use static methods for autograd extension to relieve deprecation warning in Pytorch 1.4.