### PR TITLE
Updated resample2d.py (adding simple import)

### DIFF
--- a/networks/resample2d_package/resample2d.py
+++ b/networks/resample2d_package/resample2d.py
@@ -1,3 +1,4 @@
+import torch
 from torch.nn.modules.module import Module
 from torch.autograd import Function, Variable
 import resample2d_cuda


### PR DESCRIPTION
Adding simple 'import torch' before calling 'import resample2d_cuda' allows to avoid errors in Pytorch 1.1 + Cuda 10 + Python 3.6. env of the type :  

`ImportError: local/lib/python3.6/site-packages/resample2d_cuda-0.0.0-py3.6-linux-x86_64.egg/resample2d_cuda.cpython-36m-x86_64-linux-gnu.so: undefined symbol: _ZN2at5ErrorC1ENS_14SourceLocationESs`

and possibly other env with Pytorch 0.4.1