### PR TITLE
Added Google Colab nvcc_args

### DIFF
--- a/networks/channelnorm_package/setup.py
+++ b/networks/channelnorm_package/setup.py
@@ -8,11 +8,15 @@ from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 cxx_args = ['-std=c++11']
 
 nvcc_args = [
+    '-gencode', 'arch=compute_35,code=sm_35',
+    '-gencode', 'arch=compute_37,code=sm_37',
+    '-gencode', 'arch=compute_50,code=sm_50',
     '-gencode', 'arch=compute_52,code=sm_52',
     '-gencode', 'arch=compute_60,code=sm_60',
     '-gencode', 'arch=compute_61,code=sm_61',
     '-gencode', 'arch=compute_70,code=sm_70',
-    '-gencode', 'arch=compute_70,code=compute_70'
+    '-gencode', 'arch=compute_70,code=compute_70',
+    '-gencode', 'arch=compute_75,code=sm_75'
 ]
 
 setup(

--- a/networks/correlation_package/setup.py
+++ b/networks/correlation_package/setup.py
@@ -8,12 +8,15 @@ from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 cxx_args = ['-std=c++11']
 
 nvcc_args = [
+    '-gencode', 'arch=compute_35,code=sm_35',
+    '-gencode', 'arch=compute_37,code=sm_37',
     '-gencode', 'arch=compute_50,code=sm_50',
     '-gencode', 'arch=compute_52,code=sm_52',
     '-gencode', 'arch=compute_60,code=sm_60',
     '-gencode', 'arch=compute_61,code=sm_61',
     '-gencode', 'arch=compute_70,code=sm_70',
-    '-gencode', 'arch=compute_70,code=compute_70'
+    '-gencode', 'arch=compute_70,code=compute_70',
+    '-gencode', 'arch=compute_75,code=sm_75'
 ]
 
 setup(

--- a/networks/resample2d_package/setup.py
+++ b/networks/resample2d_package/setup.py
@@ -8,12 +8,15 @@ from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 cxx_args = ['-std=c++11']
 
 nvcc_args = [
+    '-gencode', 'arch=compute_35,code=sm_35',
+    '-gencode', 'arch=compute_37,code=sm_37',
     '-gencode', 'arch=compute_50,code=sm_50',
     '-gencode', 'arch=compute_52,code=sm_52',
     '-gencode', 'arch=compute_60,code=sm_60',
     '-gencode', 'arch=compute_61,code=sm_61',
     '-gencode', 'arch=compute_70,code=sm_70',
-    '-gencode', 'arch=compute_70,code=compute_70'
+    '-gencode', 'arch=compute_70,code=compute_70',
+    '-gencode', 'arch=compute_75,code=sm_75'
 ]
 
 setup(


### PR DESCRIPTION
In order to support the 2 GPU types on Google Colab additional nvcc_args are required. 
See this [discussion](https://github.com/NVIDIA/flownet2-pytorch/issues/123#issuecomment-476806774).