### PR TITLE
Fix Dockerfile's building error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER hirakawat
 # basic packages
 RUN apt-get -y update && apt-get -y upgrade && \
         apt-get install -y sudo cmake g++ gfortran \
-        libhdf5-dev pkg-config build-essential \
+        libhdf5-dev pkg-config libffi-dev build-essential \
         wget curl git htop tmux vim ffmpeg rsync openssh-server \
         python3 python3-dev libpython3-dev && \
         apt-get -y autoremove && apt-get -y clean && apt-get -y autoclean && \
@@ -20,7 +20,7 @@ ENV LIBRARY_PATH /usr/local/nvidia/lib64:/usr/local/nvidia/lib:/usr/local/cuda/l
 
 
 # python3 modules
-RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py && \
+RUN wget https://bootstrap.pypa.io/pip/3.5/get-pip.py && python3 get-pip.py && \
         pip3 install --upgrade --no-cache-dir wheel six setuptools cython numpy scipy==1.2.0 \
                 matplotlib seaborn scikit-learn scikit-image pillow requests \
                 jupyterlab networkx h5py pandas plotly protobuf tqdm tensorboardX colorama setproctitle && \


### PR DESCRIPTION
When building docker image with Dockerfile provided, the following errors occured:

```
#0 31.96   Building wheel for cffi (setup.py): started
#0 32.22   Building wheel for cffi (setup.py): finished with status 'error'
#0 32.22   ERROR: Command errored out with exit status 1:
#0 32.22    command: /usr/bin/python3 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-9ko4csuw/cffi_f08436f7734c4c22a9d09ffe7d5e3106/setup.py'"'"'; __file__='"'"'/tmp/pip-install-9ko4csuw/cffi_f08436f7734c4c22a9d09ffe7d5e3106/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-aou35nba
#0 32.22        cwd: /tmp/pip-install-9ko4csuw/cffi_f08436f7734c4c22a9d09ffe7d5e3106/
#0 32.22   Complete output (54 lines):
#0 32.22   Package libffi was not found in the pkg-config search path.
#0 32.22   Perhaps you should add the directory containing `libffi.pc'
#0 32.22   to the PKG_CONFIG_PATH environment variable
#0 32.22   No package 'libffi' found
```

and

```
#0 0.663 2023-05-28 03:28:41 (21.5 MB/s) - 'get-pip.py' saved [2578580/2578580]
#0 0.663
#0 0.689 ERROR: This script does not work on Python 3.5 The minimum supported Python version is 3.7. Please use https://bootstrap.pypa.io/pip/3.5/get-pip.py instead.
------
Dockerfile:23
--------------------
  22 |     # python3 modules
  23 | >>> RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py && \
  24 | >>>         pip3 install --upgrade --no-cache-dir wheel six setuptools cython numpy scipy==1.2.0 \
  25 | >>>                 matplotlib seaborn scikit-learn scikit-image pillow requests \
  26 | >>>                 jupyterlab networkx h5py pandas plotly protobuf tqdm tensorboardX colorama setproctitle && \
  27 | >>>         pip3 install https://download.pytorch.org/whl/cu90/torch-1.0.0-cp35-cp35m-linux_x86_64.whl
  28 |
--------------------
```

The first error is solved by installing package "libffi-dev" and the second one is solved by substituting the link provided in the error message.